### PR TITLE
Some small pedantic styling changes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -68,12 +68,21 @@ body > header nav {
   float: right;
 }
 
-h1 {font-size: 1.9em;}
-h2 {font-size: 1.8em;}
-h3 {font-size: 1.7em;}
-h4 {font-size: 1.6em;}
-h5 {font-size: 1.5em;}
-h6 {font-size: 1.4em;}
+h1 {font-size: 1.9em; font-weight:600;}
+h2 {font-size: 1.8em; font-weight:600;}
+h3 {font-size: 1.7em; font-weight:600;}
+h4 {font-size: 1.6em; font-weight:600;}
+h5 {font-size: 1.5em; font-weight:600;}
+h6 {font-size: 1.4em; font-weight:600;}
+
+h1 a,
+h2 a,
+h3 a,
+h4 a,
+h5 a,
+h6 a {
+  text-decoration: none;
+}
 
 article {
 	border-top: 8px solid #2980b9;


### PR DESCRIPTION
pedantic emboldening and removing underlines from header links.

Turns this: 
![screen shot 2014-03-18 at 17 13 50](https://f.cloud.github.com/assets/1446145/2450948/b8bd09d6-aec0-11e3-866f-de17fae71669.png)

into this: 
![screen shot 2014-03-18 at 17 13 23](https://f.cloud.github.com/assets/1446145/2450955/bd20a514-aec0-11e3-86c9-ebd10b154420.png)
